### PR TITLE
specify envelope version

### DIFF
--- a/lib/format.js
+++ b/lib/format.js
@@ -6,6 +6,8 @@ const util = require('util');
 
 const intel = require('intel');
 
+const ENV_VERSION = "2.0";
+
 const SYSLOG_LEVELS = {};
 
 SYSLOG_LEVELS[intel.TRACE] = 7;
@@ -62,6 +64,7 @@ HekaFormatter.prototype.format = function hekaFormat(record) {
     Hostname: record.hostname,
     Severity: SYSLOG_LEVELS[record.level],
     Pid: record.pid,
+    EnvVersion: ENV_VERSION,
   };
 
   var payload = args[1];


### PR DESCRIPTION
The logging standard mozlog implements is what we're calling "2.0". We'll use this EnvVersion (previously arbitrary) to determine how to decode messages going forward.

It might be better to tie this to mozlog's version instead of a separate constant, but we don't necessarily want a full semantic version for our logging format.
