### PR TITLE
fix(format): call .toString("hex") on Buffer values

### DIFF
--- a/lib/format.js
+++ b/lib/format.js
@@ -21,6 +21,13 @@ SYSLOG_LEVELS[intel.CRITICAL] = 0;
 function json(obj) {
   var seen = [];
   return JSON.stringify(obj, function filter(key, val) {
+    if (Buffer.isBuffer(this[key])) {
+      // `val` in this case is the toJSON result on Buffer, an array of 8-bit
+      // integers. Instead, the hex format is more compact and just as useful.
+      // A string value would not match the object check below, so return now.
+      return this[key].toString('hex')
+    }
+
     if (typeof val === 'object' && val != null) {
       if (seen.indexOf(val) !== -1) {
         return '[Circular]';

--- a/test/schema.js
+++ b/test/schema.js
@@ -86,8 +86,7 @@ describe('schema', function() {
     assert.equal(out.Fields.obj, '{"foo":{"bar":"baz"},"quux":"baz"}');
   });
 
-  // worth doing? could slow things down
-  it.skip('should serialize buffers nested in objects', function() {
+  it('should serialize buffers nested in objects', function() {
     var obj = { food: Buffer('c0ffee', 'hex'), bar: 3 };
     var out = log('jsonbuffers', { obj: obj });
 


### PR DESCRIPTION
Hey @seanmonstar, I might have an open issue in one of the fxa repos, but the Buffer's are being serialized as an array of bytes. So I did this to serialize them as hex strings. Then I saw you were pondering this in the existing tests, so I did some benchmarking which addresses your correct concern (my concern too).

Results from running this gist (https://gist.github.com/jrgm/a9949b6468ae1325088e) on a production size EC2 instance.

```
I   - accept default toJSON() of buffer; simple object          
II  - convert again with toString("hex"); simple object         
III - accept default toJSON() of buffer; more realistic object  
IV  - convert again with toString("hex"); more realistic object 

(values in kops/second)
* marks the winner column

 I      II   III   IV
-----------------------
204*   202    70   71*  
220    221*   72*  71  
212*   210    73*  72  
202*   195    68   68  
206    206    70*  69  
209*   208    72*  70  
208*   207    71*  70  
202    202    68   69*  
211*   206    71*  70  
215    221*   72*  71  
```

which is a very slight edge to the way the current code runs, but might not be significant in the real world, and does reduce the size of the log files.

Of course, this might be considered a breaking change, meaning bumping to semver 2.x.x, so downstream repos don't casually pick up the change in output of the logs.