### PR TITLE
added 'stream' to config options to override stdout

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -46,7 +46,7 @@ function config(options) {
     handlers: {
       stdout: {
         class: intel.handlers.Stream,
-        stream: process.stdout,
+        stream: options.stream ? options.stream : process.stdout,
         formatter: fmt
       }
     },


### PR DESCRIPTION
`fxa-auth-server` needs to write logs to `stderr` (for now)

This adds an option to pass in a stream object that will be used instead of `process.stdout`