### PR TITLE
fix(uncaught): fix uncaught errors when debug option is on

### DIFF
--- a/lib/handler.js
+++ b/lib/handler.js
@@ -1,0 +1,39 @@
+const assert = require('assert');
+const util = require('util');
+
+const Stream = require('intel').handlers.Stream;
+const superEmit = Stream.prototype.emit;
+
+function debugAssert(record) {
+  var ex = 'logger.' + record.levelname.toLowerCase() + '(...)';
+  assert(record.args.length <= 2, ex + ' takes a maximum of 2 arguments');
+  assert.equal(typeof record.args[0], 'string',
+      ex + ' must take a String as first argument, got: '
+      + record.args[0]);
+  assert.equal(record.args[0].indexOf(' '), -1,
+      ex + ' first argument must not contain spaces, got "'
+      + record.args[0] + '"');
+}
+
+function noAssert() {}
+
+function Handler(options) {
+  Stream.call(this, options);
+
+  this.checkRecord = options.debug ? debugAssert : noAssert;
+}
+
+util.inherits(Handler, Stream);
+
+
+Handler.prototype.emit = function handlerEmit(record) {
+  if (record.uncaughtException && record.args.length === 1) {
+    record.args = ['uncaughtException', record.args[0]];
+  }
+
+  this.checkRecord(record);
+
+  superEmit.call(this, record);
+};
+
+module.exports = Handler;

--- a/lib/index.js
+++ b/lib/index.js
@@ -21,10 +21,6 @@ function logger(name) {
   return intel.getLogger(nameParts.join('.'));
 }
 
-function methodExample(levelname) {
-  return 'logger.' + levelname.toLowerCase() + '(...)';
-}
-
 function config(options) {
   app = options.app;
   var level = options.level != null ? options.level : intel.INFO;
@@ -41,30 +37,12 @@ function config(options) {
         class: HekaFormatter
       }
     },
-    filters: {
-      debug: function(record) {
-        var ex = methodExample(record.levelname);
-        assert(record.args.length <= 2, ex + ' takes a maximum of 2 arguments');
-        assert.equal(typeof record.args[0], 'string',
-            ex + ' must take a String as first argument, got: '
-            + record.args[0]);
-        assert.equal(record.args[0].indexOf(' '), -1,
-            ex + ' first argument must not contain spaces, got "'
-            + record.args[0] + '"');
-        return true;
-      },
-      uncaught: function(record) {
-        if (record.uncaughtException && record.args.length === 1) {
-          record.args = ['uncaughtException', record.args[0]];
-        }
-        return true;
-      }
-    },
     handlers: {
       stdout: {
-        class: intel.handlers.Stream,
+        class: require('./handler'),
         stream: options.stream ? options.stream : process.stdout,
-        formatter: fmt
+        formatter: fmt,
+        debug: debug
       }
     },
     loggers: {}
@@ -73,8 +51,7 @@ function config(options) {
     handlers: ['stdout'],
     handleExceptions: true,
     level: level,
-    propagate: false,
-    filters: debug ? ['uncaught', 'debug'] : ['uncaught']
+    propagate: false
   };
 
   if (options.config) {


### PR DESCRIPTION
This was previously abusing the filters to do format checking and repairing. It was fragile because the `uncaught` filter had to run before the `debug` filter.

Instead, just throw it all into a `Handler`.