### PR TITLE
Change mozlog to return instances instead of have a global logger

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,8 @@
 language: node_js
 
 node_js:
-  - '0.10'
-  - '0.12'
   - '4'
+  - '6'
 
 sudo: false
 

--- a/README.md
+++ b/README.md
@@ -11,15 +11,15 @@ npm install --save mozlog
 
 ## Usage
 
-You must configure `mozlog` one time before using it's loggers. This is
+You must create a  `mozlog` instance before using it's loggers. This is
 essentially setting the `app` name, the `level`, and the `fmt`.
 
 For the brave (or those who know `intel`'s configuration options), you
 can pass a `config` property to have fine-grained control.
 
 ```js
-// once, such as at app startup
-require('mozlog').config({
+// create your mozlog instance
+const mozlog = require('mozlog')({
   app: 'fxa-oauth-server',
   level: 'verbose', //default is INFO
   fmt: 'pretty', //default is 'heka'
@@ -35,8 +35,7 @@ developing, so the `pretty` formatter will help.
 In production, the defaults will serve you well: `info` and `heka`.
 
 ```js
-// elsewhere
-var log = require('mozlog')('routes.client.register');
+var log = mozlog('routes.client.register');
 
 log.info(op, { some: details });
 // such as

--- a/lib/index.js
+++ b/lib/index.js
@@ -2,7 +2,10 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+'use strict'
+
 const assert = require('assert');
+const util = require('util');
 
 const intel = require('intel');
 const merge = require('merge');
@@ -10,19 +13,19 @@ const merge = require('merge');
 const HekaFormatter = require('./formatters/heka');
 const PrettyFormatter = require('./formatters/pretty');
 
-var app;
+let backCompat;
 
-function logger(name) {
-  assert(app, 'mozlog.config({ app: "your-app" }) must be called first.');
-  var nameParts = [app];
-  if (name !== undefined) {
-    nameParts.push(name);
+const mozlog = function mozlog(options) {
+  if (backCompat) {
+    return backCompat(options);
   }
-  return intel.getLogger(nameParts.join('.'));
-}
 
-function config(options) {
-  app = options.app;
+  if (typeof options === 'string') {
+    options = { app: options }
+  }
+
+  assert(options.app, 'app must be a non-empty string')
+  var app = options.app;
   var level = options.level != null ? options.level : intel.INFO;
   var fmt = options.fmt || 'heka';
   var debug = !!options.debug;
@@ -58,8 +61,20 @@ function config(options) {
     merge(conf, options.config);
   }
   intel.config(conf);
+
+  return function logger(name) {
+    var nameParts = [app];
+    if (name !== undefined) {
+      nameParts.push(name);
+    }
+    return intel.getLogger(nameParts.join('.'));
+  }
 }
 
-logger.HekaFormatter = HekaFormatter;
-logger.config = config;
-module.exports = logger;
+mozlog.HekaFormatter = HekaFormatter;
+
+mozlog.config = util.deprecate(function config(opts) {
+  backCompat = mozlog(opts);
+}, 'mozlog.config() is deprecated. Use mozlog(opts) to receive a specific mozlog instance.')
+
+module.exports = mozlog;


### PR DESCRIPTION
I found I started wanting this when running the auth server and db servers in the process. Since they both independently use mozlog, the second one to try to use it ends up in a weird state.

This is quite different behavior, and I'd like to deprecate the global logger API. However, to make things easier, this does support the API from 2.0, and so could be 2.1...

cc @philbooth @vladikoff 