### PR TITLE
feat(uncaught): add uncaught option

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ const mozlog = require('mozlog')({
   app: 'fxa-oauth-server',
   level: 'verbose', //default is INFO
   fmt: 'pretty', //default is 'heka'
+  uncaught: 'exit', // default is 'log', also available as 'ignore'
   debug: true, //default is false
   stream: process.stderr //default is process.stdout
 });

--- a/lib/index.js
+++ b/lib/index.js
@@ -15,7 +15,7 @@ const PrettyFormatter = require('./formatters/pretty');
 
 let backCompat;
 
-const mozlog = function mozlog(options) {
+function mozlog(options) {
   if (backCompat) {
     return backCompat(options);
   }
@@ -24,14 +24,23 @@ const mozlog = function mozlog(options) {
     options = { app: options }
   }
 
-  assert(options.app, 'app must be a non-empty string')
-  var app = options.app;
-  var level = options.level != null ? options.level : intel.INFO;
-  var fmt = options.fmt || 'heka';
-  var debug = !!options.debug;
-  assert(fmt === 'pretty' || fmt === 'heka', 'fmt must be pretty or heka');
+  const app = options.app;
+  const level = options.level != null ? options.level : intel.INFO;
+  const fmt = options.fmt || 'heka';
+  const debug = !!options.debug;
+  // TODO: update default to 'exit', current 'log' is to not change
+  // behavior. update when going to 3.0
+  const uncaught = options.uncaught || 'log';
 
-  var conf = {
+  assert(app, 'app must be a non-empty string')
+  assert(fmt === 'pretty' || fmt === 'heka', 'fmt must be pretty or heka');
+  assert(uncaught === 'exit' || uncaught === 'log' || uncaught === 'ignore',
+    'uncaught must be either `exit`, `log`, or `ignore`');
+
+  const handleExceptions = uncaught === 'exit' || uncaught === 'log';
+  const exitOnError = uncaught === 'exit';
+
+  const conf = {
     formatters: {
       pretty: {
         class: PrettyFormatter
@@ -52,7 +61,8 @@ const mozlog = function mozlog(options) {
   };
   conf.loggers[app] = {
     handlers: ['stdout'],
-    handleExceptions: true,
+    handleExceptions: handleExceptions,
+    exitOnError: exitOnError,
     level: level,
     propagate: false
   };
@@ -63,7 +73,7 @@ const mozlog = function mozlog(options) {
   intel.config(conf);
 
   return function logger(name) {
-    var nameParts = [app];
+    const nameParts = [app];
     if (name !== undefined) {
       nameParts.push(name);
     }


### PR DESCRIPTION
This allows customizing how mozlog should interact with uncaught exceptions. Default stays the same, which is log only, but can now chose to exit or ignore also.