### PR TITLE
fix(msg): Coerce Fields.msg to a string if necessary.

### DIFF
--- a/lib/formatters/heka.js
+++ b/lib/formatters/heka.js
@@ -86,7 +86,7 @@ HekaFormatter.prototype.format = function hekaFormat(record) {
     }
     rec.Fields = fields;
   } else if (payload) {
-    rec.Fields = { msg: payload };
+    rec.Fields = { msg: '' + payload };
   }
 
   if (record.stack) {

--- a/test/schema.js
+++ b/test/schema.js
@@ -106,6 +106,12 @@ describe('schema', function() {
     assert(tv4.validate(out, HEKA_SCHEMA));
     assert.equal(out.Fields.error, 'Error: foo');
   });
+
+  it('should coerce messages to strings', function() {
+    var out = log('message', 42);
+    assert(tv4.validate(out, HEKA_SCHEMA));
+    assert.strictEqual(out.Fields.msg, '42');
+  });
 });
 
 describe('multiple instances', () => {


### PR DESCRIPTION
As noted in https://github.com/mozilla/fxa-profile-server/issues/292, the value of `Fields.msg` must be a string for the log-line to be valid mozlog.  This adds a simple coercion in the case where we create `msg` field automatically.

@jbuck r?